### PR TITLE
fix: set default compiler path

### DIFF
--- a/ServerCompilerSettings.ini
+++ b/ServerCompilerSettings.ini
@@ -1,11 +1,11 @@
 [Arduino_IDE]
-arduino_exec_path = None
+arduino_exec_path = C:\"Program Files (x86)"\Arduino\arduino_debug.exe
 arduino_board = Mega
-arduino_serial_port = COM3
+arduino_serial_port = COM4
 
 [Arduino_Sketch]
 sketch_name = DB4KSketch
-sketch_directory = k:\Escola\MyMaker\App\Repositório\DB4K
+sketch_directory = C:\Users\leona\OneDrive\Documentos\DB4K
 
 [Ardublockly]
 ide_load = upload

--- a/ardublocklyserver/compilersettings.py
+++ b/ardublocklyserver/compilersettings.py
@@ -161,7 +161,8 @@ class ServerCompilerSettings(object):
     compiler_dir = property(get_compiler_dir, set_compiler_dir)
 
     def set_compiler_dir_default(self):
-        self.__compiler_dir = None
+        # Set were the default directory fot the compiler
+        self.__compiler_dir = 'C:\\"Program Files (x86)"\\Arduino\\arduino_debug.exe'
 
     def set_compiler_dir_from_file(self, new_compiler_dir):
         """Set the compiler location, must be full path to an existing file."""


### PR DESCRIPTION
Para resolver o problema de não compilação do código, foi necessário adicionar um valor padrão para o diretório do compilador do Arduino no arquivo:  "ardublocklyserver\compilersettings.py" linha:165